### PR TITLE
Use enum class

### DIFF
--- a/text_coloring.h
+++ b/text_coloring.h
@@ -2,24 +2,24 @@
 #include <cstdlib>
 #include <sstream>
 
-enum Color {
-  BLACK,
-  RED,
-  GREEN,
-  YELLOW,
-  BLUE,
-  MAGENTA,
-  CYAN,
-  WHITE,
-  DUMMY,
-  DEFAULT,
+enum class Color {
+  BLACK = 0,
+  RED = 1,
+  GREEN = 2,
+  YELLOW = 3,
+  BLUE = 4,
+  MAGENTA = 5,
+  CYAN = 6,
+  WHITE = 7,
+  /* DUMMY = 8, */
+  DEFAULT = 9,
 };
 
 namespace {
   char textcolor[] = {0x1b, '[', '1', ';', '3'};
   std::string getColorCode(Color c) {
     std::stringstream ss;
-    ss << textcolor << c << "m";
+    ss << textcolor << static_cast<int>(c) << "m";
     return ss.str();
   }
 }  // namespace
@@ -27,6 +27,6 @@ namespace {
 
 std::string coloringText(std::string str, Color c) {
   std::stringstream ss;
-  ss << getColorCode(c) << str << getColorCode(DEFAULT);
+  ss << getColorCode(c) << str << getColorCode(Color::DEFAULT);
   return ss.str();
 }


### PR DESCRIPTION
It's only available with C++11 or later, so feel free to reject it if you want to make this library usable with C++03 or older.